### PR TITLE
Add project: Wayback-Archive

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2007,3 +2007,7 @@ projects:
     pypi_id: pipeless-ai
     category: computer-vision
     description: An open-source framework to create and deploy computer vision applications in minutes.
+  - name: Wayback-Archive
+    github_id: GeiserX/Wayback-Archive
+    category: data-loading
+    description: Download complete websites from the Wayback Machine with full asset preservation for offline viewing.


### PR DESCRIPTION
## Summary

- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the `data-loading` category in `projects.yaml`.
- Wayback-Archive is a Python tool (GPL-3.0) that downloads complete websites from the Wayback Machine with full asset preservation (HTML, CSS, JS, images) for offline viewing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Wayback-Archive` to the `data-loading` category in `projects.yaml` to list a tool that downloads complete Wayback Machine sites with full asset preservation for offline viewing.

<sup>Written for commit 4f60317b2ec84bb377e417a5e821747377c37360. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

