### PR TITLE
Add dttb - timestamps for Python exception tracebacks

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1034,6 +1034,11 @@ projects:
     category: inspect
     pypi_id: typing_inspect
     conda_id: conda-forge/typing_inspect
+  - name: dttb
+    github_id: rocky-d/dttb
+    category: inspect
+    pypi_id: dttb
+    description: Add timestamps to Python exception tracebacks with a single line of code.
   - name: gsheets-db-api
     github_id: betodealmeida/gsheets-db-api
     category: db-clients


### PR DESCRIPTION
## Add dttb

**[dttb](https://github.com/rocky-d/dttb)** adds timestamps to Python exception tracebacks with a single line of code.

```python
import dttb; dttb.apply()
```

Every subsequent traceback will include a timestamp showing exactly when the exception occurred — invaluable for debugging long-running services, async applications, and multi-threaded programs.

**Features:**
- Patches `sys.excepthook` and `threading.excepthook`
- Timezone configuration
- Custom callbacks
- Zero dependencies

**Links:**
- GitHub: https://github.com/rocky-d/dttb
- PyPI: https://pypi.org/project/dttb/
- Docs: https://rocky-d.github.io/dttb/

I've placed this under the `inspect` category as it relates to Python runtime introspection and debugging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `dttb` to the `inspect` catalog, a zero-dependency tool that adds timestamps to Python exception tracebacks. This entry includes GitHub, PyPI, and a short description in `projects.yaml` to make the package discoverable.

<sup>Written for commit c65ceffce774d029615b1bf1856bc567c0e7fe41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

