### PR TITLE
Add cloud-audit to Infrastructure & DevOps category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -732,7 +732,6 @@ projects:
     github_id: gebalamariusz/cloud-audit
     category: infrastructure
     pypi_id: cloud-audit
-    conda_id: conda-forge/awscli
   - name: deepdiff
     github_id: seperman/deepdiff
     category: inspect

--- a/projects.yaml
+++ b/projects.yaml
@@ -728,6 +728,11 @@ projects:
     category: infrastructure
     pypi_id: awscli
     conda_id: conda-forge/awscli
+  - name: cloud-audit
+    github_id: gebalamariusz/cloud-audit
+    category: infrastructure
+    pypi_id: cloud-audit
+    conda_id: conda-forge/awscli
   - name: deepdiff
     github_id: seperman/deepdiff
     category: inspect


### PR DESCRIPTION
Adds [cloud-audit](https://github.com/gebalamariusz/cloud-audit) to the Infrastructure & DevOps category.

cloud-audit is an open-source AWS security scanner written in Python (MIT license).

- **PyPI:** `pip install cloud-audit`
- **GitHub:** https://github.com/gebalamariusz/cloud-audit
- 47 curated checks with AWS CLI and Terraform remediation
- Attack chain detection and diff command for CI/CD
- SARIF output for GitHub Code Scanning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cloud-audit` to the Infrastructure & DevOps catalog to surface an open-source AWS security scanner.
Updates `projects.yaml` to include `github_id: gebalamariusz/cloud-audit` and `pypi_id: cloud-audit`, and removes an incorrect `conda_id`.

<sup>Written for commit 424dfec1f57fcd665ae3b8919753f2b519d797a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

