### PR TITLE
Add uk-company-number and uk-sic-codes to Data Validation

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2007,3 +2007,15 @@ projects:
     pypi_id: pipeless-ai
     category: computer-vision
     description: An open-source framework to create and deploy computer vision applications in minutes.
+  - name: uk-company-number
+    github_id: borschai/uk-company-number
+    pypi_id: uk-company-number
+    npm_id: uk-company-number
+    category: data-validation
+    description: Validate, format, and identify UK Companies House company numbers. Supports all 27 prefixes.
+  - name: uk-sic-codes
+    github_id: borschai/uk-sic-codes
+    pypi_id: uk-sic-codes
+    npm_id: uk-sic-codes
+    category: data-validation
+    description: UK SIC 2007 industry classification code lookup, search, and validation. 731 codes, 21 sections.


### PR DESCRIPTION
## Summary

Adds two UK company data validation packages to the Data Validation category:

- **uk-company-number** — Validate, format, and identify UK Companies House company numbers. Supports all 27 prefixes (England & Wales, Scotland, NI, LLP, LP, etc.). Zero dependencies. [PyPI](https://pypi.org/project/uk-company-number/) · [npm](https://www.npmjs.com/package/uk-company-number)
- **uk-sic-codes** — UK SIC 2007 industry classification code lookup, search, and validation. 731 codes, 21 sections. Zero dependencies. [PyPI](https://pypi.org/project/uk-sic-codes/) · [npm](https://www.npmjs.com/package/uk-sic-codes)

These are the only open-source packages for UK company number validation and SIC code lookup on PyPI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `uk-company-number` and `uk-sic-codes` to the Data Validation catalog in `projects.yaml`. This adds UK Companies House number validation/formatting and UK SIC 2007 code lookup/validation with GitHub, PyPI, and npm metadata.

<sup>Written for commit 95d8debac5f926b9abf031f18e8a7b2a493697c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

