### PR TITLE
Add crdt-merge — CRDT-backed merge library

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2007,3 +2007,9 @@ projects:
     pypi_id: pipeless-ai
     category: computer-vision
     description: An open-source framework to create and deploy computer vision applications in minutes.
+- name: crdt-merge
+  github_id: mgillr/crdt-merge
+  pypi_id: crdt-merge
+  category: data-containers
+  description: "Conflict-free merge for DataFrames, ML models & distributed agents — powered by CRDTs"
+


### PR DESCRIPTION
Hi! 👋

I'd like to add [crdt-merge](https://github.com/mgillr/crdt-merge) to the data-containers category.

**crdt-merge** ensures every merge operation (tabular data, model weights, agent memory) is mathematically guaranteed to converge — commutative, associative, and idempotent.

- 2,600+ tests, 26 merge strategies
- Works with pandas, Polars, DuckDB, Arrow
- PyPI: `pip install crdt-merge`

Thanks! 🙏

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `crdt-merge` to the `data-containers` category. It’s a CRDT-backed merge library for DataFrames, ML models, and distributed agents that guarantees convergent, conflict-free merges.

<sup>Written for commit dfa66bb9c182e746fc7158177244b3eb506d1fa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

