### PR TITLE
Add minify-obfuscate-cli to CLI Development

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -325,6 +325,10 @@ projects:
     category: cli-helpers
     pypi_id: click
     conda_id: conda-forge/click
+  - name: doc-engine-cli
+    github_id: leonardosalasd/doc-engine-cli
+    category: cli-helpers
+    pypi_id: doc-engine-cli
   - name: minify-obfuscate-cli
     github_id: leonardosalasd/minify-obfuscate-cli
     category: cli-helpers

--- a/projects.yaml
+++ b/projects.yaml
@@ -325,6 +325,9 @@ projects:
     category: cli-helpers
     pypi_id: click
     conda_id: conda-forge/click
+  - name: minify-obfuscate-cli
+    github_id: leonardosalasd/minify-obfuscate-cli
+    category: cli-helpers
   - name: clint
     github_id: kennethreitz-archive/clint
     category: cli-helpers


### PR DESCRIPTION
Hello! I've developed minify-obfuscate-cli, a zero-config Python orchestrator designed to bulk minify HTML/CSS and obfuscate JavaScript. It acts as a bridge to industry-standard node engines, providing a unified build pipeline for web projects directly from the terminal. I believe it adds solid value to the CLI ecosystem of this list. Thank you for maintaining this awesome project!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `minify-obfuscate-cli` and `doc-engine-cli` to the `cli-helpers` category in the project catalog. `minify-obfuscate-cli` is a zero-config Python CLI that orchestrates Node-based tools to bulk minify HTML/CSS and obfuscate JavaScript; `doc-engine-cli` is a zero-config CLI that converts Markdown to high-quality PDFs using `mistune` and `typst` (no LaTeX).

<sup>Written for commit a2e74a460f570434549e54155b951b1b6e3bb60a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

