### PR TITLE
Add project: atomic-lru-cache

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -464,6 +464,10 @@ projects:
     category: caching
     pypi_id: cachetools
     conda_id: conda-forge/cachetools
+  - name: atomic-lru-cache
+    github_id: ElromEvedElElyon/atomic-lru-cache
+    category: caching
+    labels: ["python"]
   - name: questionary
     github_id: tmbo/questionary
     category: cli-helpers


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project

**Description:**

Adds `atomic-lru-cache` to the `caching` category.

atomic-lru-cache is a persistent LRU cache with atomic writes and portable file locking. It is a drop-in replacement for `functools.lru_cache` that survives process restarts, without requiring SQLite or any external dependencies (pure stdlib). Uses `os.replace` for atomic writes and `msvcrt`/`fcntl` for portable, fork-safe file locking, making it suitable for multi-process workloads where existing options (`cachetools`, `cachier`, `cached-property`) are either in-memory only or carry heavier dependencies.

Repo: https://github.com/ElromEvedElElyon/atomic-lru-cache

**Checklist:**

- [x] I have read the CONTRIBUTING guidelines.
- [x] I have not modified the README.md file (only projects.yaml).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `atomic-lru-cache` to the `caching` category. This surfaces a persistent, atomic-write LRU cache for Python that works across processes without external dependencies.

<sup>Written for commit 19f64fe9b819a470904c5ea1102c0b9e45f55bb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

