### PR TITLE
Add project: pdfmux

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1392,6 +1392,11 @@ projects:
     github_id: camelot-dev/camelot
     category: data-loading
     pypi_id: camelot
+  - name: pdfmux
+    github_id: NameetP/pdfmux
+    category: data-loading
+    pypi_id: pdfmux
+    labels: ["python", "pdf", "markdown"]
   - name: excalibur
     github_id: camelot-dev/excalibur
     category: data-loading


### PR DESCRIPTION
Adding [pdfmux](https://github.com/NameetP/pdfmux) to the `data-loading` category.

### What it is
A Python library and CLI for converting PDFs to Markdown for LLM and RAG pipelines. It classifies each PDF page (digital text, scanned, tables, mixed) and routes it to the optimal backend — PyMuPDF for digital text, Docling for tables, RapidOCR for scans, Gemini Flash for hard pages — then attaches a per-page confidence score so data pipelines can quarantine low-trust pages.

### Why it fits
- **data-loading** is described as "Libraries for loading, collecting, and extracting data from a variety of data sources and formats." — pdfmux extracts structured Markdown + metadata from PDFs, exactly the category's scope.
- Sits next to existing peers in the same category: `camelot` (PDF table extraction), `tabulator-py`, `messytables`.
- Differentiator is the confidence scoring + router; no other data-loading entry orchestrates multiple backends with per-page quality gating.

### Quick facts
- PyPI: `pip install pdfmux`
- MIT licensed
- Active maintainership: v1.5.0 released April 2026 (6 releases since launch)
- First-party LangChain + LlamaIndex loaders
- Built-in MCP server

### Follows CONTRIBUTING.md
- ✅ Added to `projects.yaml` (not `README.md` directly)
- ✅ Individual PR for this single project
- ✅ Title format: `Add project: pdfmux`
- ✅ Category assigned: `data-loading`
- ✅ Includes `github_id`, `pypi_id`, and relevant `labels`

Happy to address any maintainer feedback on category fit or metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `pdfmux` to the `data-loading` category in `projects.yaml`. It converts PDFs to Markdown for LLM/RAG, classifies pages, routes them to PyMuPDF/Docling/RapidOCR/Gemini Flash, and outputs per-page confidence scores.

<sup>Written for commit 40e7c1f0dc884697c0c20b984ade83d7cccda894. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

