### PR TITLE
Add DeepAlpha to machine-learning category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2016,3 +2016,7 @@ projects:
     github_id: GeiserX/Wayback-Archive
     category: data-loading
     description: Download complete websites from the Wayback Machine with full asset preservation for offline viewing.
+- name: DeepAlpha
+  github_id: stefanoviana/deepalpha
+  category: machine-learning
+  description: AI crypto trading bot with ML ensemble (XGBoost, LightGBM), 72 features, pump scanner, Grid/DCA bots, 12 exchanges.


### PR DESCRIPTION
Hi! Adding [DeepAlpha](https://github.com/stefanoviana/deepalpha) to the Machine Learning & Data Engineering category.

DeepAlpha is an open-source AI crypto trading engine featuring:
- ML ensemble models (XGBoost, LightGBM) with 72 engineered features
- Pump scanner for real-time momentum detection
- Grid and DCA trading bots
- 12 exchange support via CCXT
- Walk-forward validation and backtesting
- Telegram control panel

Thanks for maintaining this awesome list!