### PR TITLE
Add project: oracle3

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2016,3 +2016,7 @@ projects:
     github_id: GeiserX/Wayback-Archive
     category: data-loading
     description: Download complete websites from the Wayback Machine with full asset preservation for offline viewing.
+  - name: oracle3
+    github_id: YichengYang-Ethan/oracle3
+    category: machine-learning
+    description: Autonomous prediction-market trading agent applying the Wang Transform pricing model (calibrated on 291k resolved contracts) across Kalshi, Polymarket, and Solana, with hierarchical MLE, model Greeks, Kelly-sized execution, and eight constraint-based arbitrage strategies.


### PR DESCRIPTION
Adding [oracle3](https://github.com/YichengYang-Ethan/oracle3) to `projects.yaml`.

oracle3 is an autonomous Python trading agent for prediction markets (Kalshi, Polymarket, Solana DFlow). It implements the Wang Transform pricing engine calibrated on 291,309 resolved contracts (lambda-hat = 0.183, p < 1e-15), with hierarchical MLE estimation, model Greeks, Kelly sizing, and eight constraint-based arbitrage strategies.

**Working paper**: [Pricing Prediction Markets: Risk Premiums, Incomplete Markets, and a Decomposition Framework](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6468338) (Yang, 2026, UIUC)

### Quality signals
- License: **Apache 2.0**
- Stars: **170+**
- Activity: v1.1.0 released 2026-05; regular commits
- Tests: 633 passing; mypy + ruff + codespell on every push
- Type hints: mypy strict on most modules
- Documentation: full [docs site](https://yichengyang-ethan.github.io/oracle3)
- Pre-commit hooks configured; issue/PR templates + CITATION

### Category placement
Placed under `machine-learning` (Machine Learning & Data Engineering) as the closest fit, given the Wang Transform pricing model, hierarchical MLE estimation, and Kelly-sized execution. oracle3 is not on PyPI yet, so no `pypi_id` is included. Happy to adjust the category, description, or YAML formatting if anything is off.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `oracle3` to `projects.yaml` under `machine-learning`. This makes the project discoverable in the catalog with a short description of its Wang Transform-based prediction-market trading agent for Kalshi, Polymarket, and Solana.

<sup>Written for commit dd641471bda45b70dc616bec927fc1fe0c85d771. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

