### PR TITLE
Add 9 Python developer tools: CLI, DevOps, and data utilities

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -911,6 +911,9 @@ projects:
     category: cli-helpers
     pypi_id: typer
     conda_id: conda-forge/typer
+  - name: click-to-mcp
+    github_id: Coding-Dev-Tools/click-to-mcp
+    category: cli-helpers
   - name: keyboard
     github_id: boppreh/keyboard
     category: os-utils
@@ -1767,6 +1770,12 @@ projects:
     category: infrastructure
     conda_id: conda-forge/pypyr
     pypi_id: pypyr
+  - name: deploydiff
+    github_id: Coding-Dev-Tools/deploydiff
+    category: infrastructure
+  - name: configdrift
+    github_id: Coding-Dev-Tools/configdrift
+    category: infrastructure
   - name: dirty-equals
     github_id: samuelcolvin/dirty-equals
     category: data-validation
@@ -2016,3 +2025,27 @@ projects:
     github_id: GeiserX/Wayback-Archive
     category: data-loading
     description: Download complete websites from the Wayback Machine with full asset preservation for offline viewing.
+  - name: api-contract-guardian
+    github_id: Coding-Dev-Tools/api-contract-guardian
+    category: dev-utils
+    description: Validate API contracts against OpenAPI specs with zero config.
+  - name: json2sql
+    github_id: Coding-Dev-Tools/json2sql
+    category: data-loading
+    description: Convert JSON files to SQL schemas and INSERT statements.
+  - name: deadcode
+    github_id: Coding-Dev-Tools/deadcode
+    category: dev-utils
+    description: Detect and remove dead code from Python projects.
+  - name: datamorph
+    github_id: Coding-Dev-Tools/datamorph
+    category: data-pipelines
+    description: Transform data between formats (CSV, JSON, YAML, Parquet) with a single command.
+  - name: envault
+    github_id: Coding-Dev-Tools/envault
+    category: configuration
+    description: Encrypt and manage .env files with Vault-style security.
+  - name: schemaforge
+    github_id: Coding-Dev-Tools/schemaforge
+    category: data-validation
+    description: Generate JSON Schema from sample data automatically.


### PR DESCRIPTION
Adds 9 open-source Python developer tools from the Revenue Holdings ecosystem.

CLI Development:
- click-to-mcp - Auto-wrap Click/Typer CLIs as MCP servers (cli-helpers)

Infrastructure and DevOps:
- deploydiff - Compare deployments to detect configuration drift (infrastructure)
- configdrift - Track and detect infrastructure configuration changes (infrastructure)

Data and Validation:
- json2sql - Convert JSON to SQL schemas and INSERT statements (data-loading)
- datamorph - Transform data between CSV/JSON/YAML/Parquet formats (data-pipelines)
- schemaforge - Generate JSON Schema from sample data automatically (data-validation)

Developer Utilities:
- api-contract-guardian - Validate API contracts against OpenAPI specs (dev-utils)
- deadcode - Detect and remove dead code from Python projects (dev-utils)

Configuration:
- envault - Encrypt and manage .env files with Vault-style security (configuration)

All tools are actively maintained, MIT-licensed, available on GitHub under Coding-Dev-Tools.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds nine Python developer tools to the catalog in `projects.yaml` to cover CLI wrapping, infra drift detection, data transforms/validation, API contract checks, dead code detection, and .env encryption. This improves tool discoverability across CLI, DevOps, data, and config workflows.

- **New Features**
  - CLI: `click-to-mcp` — auto-wrap Click/Typer CLIs as MCP servers.
  - Infra/DevOps: `deploydiff`, `configdrift` — detect deployment and configuration drift.
  - Data: `json2sql`, `datamorph`, `schemaforge` — JSON→SQL, format transforms, JSON Schema generation.
  - Dev utilities: `api-contract-guardian`, `deadcode` — OpenAPI contract checks, dead code detection.
  - Configuration: `envault` — encrypt and manage .env files.

<sup>Written for commit 7d309c68dd49cb333adcc8ff11efa936c954ef41. Summary will update on new commits. <a href="https://cubic.dev/pr/lukasmasuch/best-of-python/pull/292?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

