### PR TITLE
Add 7 open-source Python CLI tools from Coding-Dev-Tools

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2006,6 +2006,34 @@ projects:
     github_id: grai-io/grai-core
     pypi_id: the-guide
     category: infrastructure
+  - name: DeployDiff
+    github_id: Coding-Dev-Tools/deploydiff
+    category: infrastructure
+    description: Compare infrastructure deployments across environments to detect drift and prevent inconsistencies.
+  - name: ConfigDrift
+    github_id: Coding-Dev-Tools/configdrift
+    category: infrastructure
+    description: Detect and track configuration drift across infrastructure to maintain consistency and compliance.
+  - name: API Contract Guardian
+    github_id: Coding-Dev-Tools/api-contract-guardian
+    category: infrastructure
+    description: Validate OpenAPI contracts in CI/CD pipelines to prevent breaking changes from reaching production.
+  - name: Envault
+    github_id: Coding-Dev-Tools/envault
+    category: cryptography
+    description: CLI tool for managing encrypted .env files with team sharing and version control.
+  - name: click-to-mcp
+    github_id: Coding-Dev-Tools/click-to-mcp
+    category: cli-helpers
+    description: Auto-wrap Click/Typer CLI tools as MCP servers, making them accessible to AI assistants.
+  - name: Json2SQL
+    github_id: Coding-Dev-Tools/json2sql
+    category: db-clients
+    description: Convert JSON files and API responses to SQL schemas and INSERT statements.
+  - name: SchemaForge
+    github_id: Coding-Dev-Tools/schemaforge
+    category: data-validation
+    description: Validate and generate data schemas from JSON/YAML with automatic inference and linting.
     description: Platform to programmatically manage, test, and debug data infrastructure.
   - name: Pipeless
     github_id: pipeless-ai/pipeless


### PR DESCRIPTION
## Added Python CLI Tools

Seven open-source Python CLI tools added to projects.yaml across relevant categories:

| Tool | Category | Description |
|------|----------|-------------|
| [DeployDiff](https://github.com/Coding-Dev-Tools/deploydiff) | Infrastructure | Compare deployments across environments |
| [ConfigDrift](https://github.com/Coding-Dev-Tools/configdrift) | Infrastructure | Configuration drift detection |
| [API Contract Guardian](https://github.com/Coding-Dev-Tools/api-contract-guardian) | Infrastructure | OpenAPI contract validation in CI/CD |
| [Envault](https://github.com/Coding-Dev-Tools/envault) | Cryptography | Encrypted .env file management |
| [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) | CLI Development | Auto-wrap CLIs as MCP servers |
| [Json2SQL](https://github.com/Coding-Dev-Tools/json2sql) | Database Clients | JSON-to-SQL conversion |
| [SchemaForge](https://github.com/Coding-Dev-Tools/schemaforge) | Data Validation | Schema validation and generation |

All tools are MIT-licensed Python packages with CI passing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added seven open-source Python CLI tools to projects.yaml to expand coverage across infrastructure, cryptography, CLI helpers, database clients, and data validation. All are MIT-licensed Python packages.

- **New Features**
  - `DeployDiff` — Infrastructure: compare deployments across environments.
  - `ConfigDrift` — Infrastructure: detect configuration drift.
  - `API Contract Guardian` — Infrastructure: validate OpenAPI in CI/CD.
  - `Envault` — Cryptography: manage encrypted .env files.
  - `click-to-mcp` — CLI helpers: wrap Click/Typer CLIs as MCP servers.
  - `Json2SQL` — Database clients: convert JSON to SQL.
  - `SchemaForge` — Data validation: validate and generate schemas.

<sup>Written for commit f993f77687db912dc35eb97430be3d65dc6e129a. Summary will update on new commits. <a href="https://cubic.dev/pr/lukasmasuch/best-of-python/pull/294?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

