### PR TITLE
Add DevForge CLI tools: infrastructure and data-validation

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -371,6 +371,22 @@ projects:
     github_id: pulumi/pulumi
     category: infrastructure
     pypi_id: pulumi
+  - name: DeployDiff
+    github_id: Coding-Dev-Tools/deploydiff
+    category: infrastructure
+    pypi_id: deploydiff
+  - name: ConfigDrift
+    github_id: Coding-Dev-Tools/configdrift
+    category: infrastructure
+    pypi_id: configdrift
+  - name: API Contract Guardian
+    github_id: Coding-Dev-Tools/api-contract-guardian
+    category: infrastructure
+    pypi_id: api-contract-guardian
+  - name: APIGhost
+    github_id: Coding-Dev-Tools/apighost
+    category: infrastructure
+    pypi_id: apighost
     npm_id: '@pulumi/pulumi'
   - name: plumbum
     github_id: tomerfiliba/plumbum
@@ -1772,6 +1788,10 @@ projects:
     category: data-validation
     conda_id: conda-forge/dirty-equals
     pypi_id: dirty-equals
+  - name: SchemaForge
+    github_id: Coding-Dev-Tools/schemaforge
+    category: data-validation
+    pypi_id: schemaforge-py
   - name: everett
     github_id: willkg/everett
     category: configuration


### PR DESCRIPTION
## Add 5 Python developer tools from DevForge ecosystem

Adding open-source Python CLI tools that solve real engineering problems:

**Infrastructure & DevOps:**
- **DeployDiff** - Preview infrastructure changes with human-readable diffs, cost impact estimation, and rollback commands. Supports Terraform, CloudFormation, Pulumi.
- **ConfigDrift** - Detect configuration drift across environments. Compares YAML/JSON/TOML/.env files, flags drifting keys before incidents.
- **API Contract Guardian** - Prevent API contract violations before production. Detects breaking OpenAPI changes in CI pipelines.
- **APIGhost** - Lightweight API mock server from OpenAPI specs. Zero-config testing for API development.

**Data Validation:**
- **SchemaForge** - Bidirectional ORM schema conversion across 11 formats (SQLAlchemy, Django, Prisma, Tortoise, etc.) with VS Code extension.

All tools are MIT licensed, available on PyPI, and have passing CI/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add five DevForge CLI tools to the registry to expand infrastructure and data-validation coverage. Entries added in `projects.yaml` so these tools appear in the catalog.

- **New Features**
  - DeployDiff (`deploydiff`, infrastructure) – human-readable infra diffs with cost and rollback; supports Terraform/CloudFormation/Pulumi.
  - ConfigDrift (`configdrift`, infrastructure) – detects config drift across envs for YAML/JSON/TOML/.env.
  - API Contract Guardian (`api-contract-guardian`, infrastructure) – prevents breaking OpenAPI changes in CI.
  - APIGhost (`apighost`, infrastructure) – mock server from OpenAPI specs for testing.
  - SchemaForge (`schemaforge-py`, data-validation) – converts ORM schemas across multiple formats.

<sup>Written for commit 1a5e36fc9684c6239b551eea8224f1b4b2c3ffd7. Summary will update on new commits. <a href="https://cubic.dev/pr/lukasmasuch/best-of-python/pull/296?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

