### PR TITLE
Add project: traceburn

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2016,3 +2016,7 @@ projects:
     github_id: GeiserX/Wayback-Archive
     category: data-loading
     description: Download complete websites from the Wayback Machine with full asset preservation for offline viewing.
+  - name: traceburn
+    github_id: TommyTranX/traceburn
+    pypi_id: traceburn
+    description: Local-first tracer and cost profiler for AI agents; finds and quantifies wasted LLM spend and prints fixes for common waste patterns.


### PR DESCRIPTION
Adds traceburn to projects.yaml, uncategorized (no existing category is a close fit; per CONTRIBUTING.md, uncategorized projects sort under Others).

traceburn is a local-first, MIT-licensed cost and efficiency profiler for AI agents built on the openai and anthropic Python SDKs (plus litellm). It finds and quantifies wasted LLM spend (duplicate calls, missed prompt caching, context bloat, model overkill, retry loops) and prints a mechanical fix for two of the five patterns. Runs against one local SQLite file, no account or server required.

Repo: https://github.com/TommyTranX/traceburn
PyPI: https://pypi.org/project/traceburn/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `traceburn` to projects.yaml with name, GitHub repo, PyPI ID, and description. It's a local-first LLM cost profiler that finds wasted spend and suggests fixes; added uncategorized (shows under Others).

<sup>Written for commit 4b819d12f10c6fbb2dba8cbe23334d3136e51e9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukasmasuch/best-of-python/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

