### PR TITLE
Add project: pythonlings

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2016,3 +2016,6 @@ projects:
     github_id: GeiserX/Wayback-Archive
     category: data-loading
     description: Download complete websites from the Wayback Machine with full asset preservation for offline viewing.
+  - name: Pythonlings
+    github_id: abhiksark/pythonlings
+    pypi_id: pythonlings


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

Adds Pythonlings, a Rustlings-style Python learning project with interactive terminal exercises, automatic checks, hints, and offline documentation. The category is omitted because the current taxonomy has no education or learning category, so the project will be placed under Others.

I maintain Pythonlings and am submitting it for maintainer review.

**Checklist:**

- [x] I have read the CONTRIBUTING guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.

**Validation:**

Parsed `projects.yaml` and confirmed exactly one entry for `abhiksark/pythonlings`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Pythonlings to the project catalog so the interactive Python learning tool appears in generated listings. Category is omitted since the taxonomy lacks an education/learning type; it should default to Others.

- Confirm the generator accepts entries without `category` and places the project under Others.
- Verify `github_id` `abhiksark/pythonlings` and `pypi_id` `pythonlings` resolve and render correctly.

<sup>Written for commit dbad9a4e390bdefea2e0b7284afe050e1308d403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lukasmasuch/best-of-python/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

